### PR TITLE
Adding a new Udemy course link to /learn page

### DIFF
--- a/content/learn/index.html
+++ b/content/learn/index.html
@@ -281,6 +281,7 @@ Find <a href="/contribute/ides.html">here</a> how to work with Wicket projects w
 
 <ul>
   <li><a href="https://www.udemy.com/course/apache-wicket-kompakt/">Apache Wicket Kompakt</a> - A complete German-based course with many pratical examples.</li>
+  <li><a href="https://www.udemy.com/course/starting-with-apache-wicket-version-9x/?referralCode=C2A6EF19A72071AA2E22">Starting with Apache Wicket (version 9.x+)</a> - Get started with Apache Wicket 9.x+ with forms, components, MongoDB, GridFS and backed by SpringBoot.</li>
 </ul>
 
 <hr />

--- a/learn/index.md
+++ b/learn/index.md
@@ -144,6 +144,7 @@ Find [here]({{ site.baseurl }}/contribute/ides.html) how to work with Wicket pro
 ## Online courses {#courses}
 
 - <a href="https://www.udemy.com/course/apache-wicket-kompakt/">Apache Wicket Kompakt</a> - A complete German-based course with many pratical examples.
+- <a href="https://www.udemy.com/course/starting-with-apache-wicket-version-9x/?referralCode=C2A6EF19A72071AA2E22">Starting with Apache Wicket (version 9.x+)</a> - Get started with Apache Wicket 9.x+ with forms, components, MongoDB, GridFS and backed by SpringBoot.
 
 ---
 


### PR DESCRIPTION
I have released a new Udemy course in english language named "Starting with Apache Wicket 9.x". I found an 'Online courses' section on your web site so please consider adding this link to existing one ...

thank you
David Marko